### PR TITLE
refactor: 로그인시 암호비교 로직 BCrypt -> 평문

### DIFF
--- a/src/main/java/org/moa/global/security/config/SecurityConfig.java
+++ b/src/main/java/org/moa/global/security/config/SecurityConfig.java
@@ -20,6 +20,7 @@ import org.springframework.security.config.annotation.web.configuration.WebSecur
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.NoOpPasswordEncoder;
 import org.springframework.security.web.access.channel.ChannelProcessingFilter;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.security.web.csrf.CsrfFilter;
@@ -34,7 +35,7 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 @Configuration
 @EnableWebSecurity
-@MapperScan(basePackages = {"org.moa.member.mapper", "org.moa.global.mapper"})
+@MapperScan(basePackages = {"org.moa.member.mapper"})
 @ComponentScan(basePackages = {"org.moa.global.security"})
 @RequiredArgsConstructor
 public class SecurityConfig extends WebSecurityConfigurerAdapter {
@@ -55,6 +56,12 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
 	@Bean
 	public BCryptPasswordEncoder passwordEncoder() {
 		return new BCryptPasswordEncoder(); // 보안 설정의 일환
+	}
+
+	@Bean
+	@SuppressWarnings("deprecation") // NoOpPasswordEncoder는 deprecated
+	public NoOpPasswordEncoder encoder() {
+		return (NoOpPasswordEncoder)NoOpPasswordEncoder.getInstance();
 	}
 
 	//AuthenticationManager 빈 등록
@@ -141,6 +148,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
 	protected void configure(AuthenticationManagerBuilder auth) throws Exception {
 		auth
 			.userDetailsService(userDetailsService)
-			.passwordEncoder(passwordEncoder()); // 여기까지가 DB 인증 방식
+			// .passwordEncoder(passwordEncoder()); // 암호화 방식
+			.passwordEncoder(encoder()); // 암호화 방식
 	}
 }

--- a/src/main/java/org/moa/member/service/MemberServiceImpl.java
+++ b/src/main/java/org/moa/member/service/MemberServiceImpl.java
@@ -71,13 +71,24 @@ public class MemberServiceImpl implements MemberService {
 			throw new IllegalArgumentException("일치하는 계좌 정보가 없습니다.");
 		}
 
-		// Member 생성 및 저장
+		// // Member 생성 및 저장
+		// Member member = Member.builder()
+		// 	.memberType(dto.getRole())
+		// 	.email(dto.getEmail())
+		// 	.password(hashUtil.hash(dto.getPassword()))
+		// 	.name(dto.getName())
+		// 	.idCardNumber(hashUtil.hash(dto.getIdCardNumber()))
+		// 	.createdAt(java.time.LocalDateTime.now())
+		// 	.updatedAt(java.time.LocalDateTime.now())
+		// 	.build();
+
+		// Member 생성 및 저장 -> 비밀번호 평문으로
 		Member member = Member.builder()
 			.memberType(dto.getRole())
 			.email(dto.getEmail())
-			.password(hashUtil.hash(dto.getPassword()))
+			.password(dto.getPassword())
 			.name(dto.getName())
-			.idCardNumber(hashUtil.hash(dto.getIdCardNumber()))
+			.idCardNumber(dto.getIdCardNumber())
 			.createdAt(java.time.LocalDateTime.now())
 			.updatedAt(java.time.LocalDateTime.now())
 			.build();


### PR DESCRIPTION
## PR 종류
사용하지 않는 PR 종류는 삭제해주세요  
- [ ] 기능 개선
- [ ] 새로운 기능
- [x] 리팩토링
- [ ] 문서 수정
- [ ] 기타

## 변경 사항

- 회원가입시 비밀번호를 BCyrpt -> 평문방식으로 바꿨습니다.
- 기존 : 로그인시 비밀번호를 암호화하여 테스트시 "1234"와 같은 값으로 DML 코드 작성시, 비밀번호 틀림 문제 발생
- 변경 : 로그인시 비밀번호 비교 로직을 암호화 -> 평문방식으로 바꾸어 테스트시 용이

## 관련 이슈

- 관련된 이슈 번호를 적어주세요 (#2 )

## 체크리스트

- [ ] 테스트 코드를 작성하였나요?
- [ ] 모든 테스트가 통과하나요?
- [ ] 관련 문서를 업데이트했나요?
- [ ] 코드 컨벤션을 지켰나요?

## 상세 내용

- 필요한 경우 스크린샷을 첨부해주세요.

## 기타

- 추가로 알려야 할 사항이 있다면 적어주세요.
