### PR TITLE
fix: 예약 내역 생성 QR

### DIFF
--- a/src/main/java/org/moa/global/controller/MemberQrController.java
+++ b/src/main/java/org/moa/global/controller/MemberQrController.java
@@ -59,24 +59,37 @@ public class MemberQrController {
     // 사용자 예약 내역 QR 조회 API
     @GetMapping("/reservation")
     public ResponseEntity<ApiResponse<String>> generateReservationQr(@AuthenticationPrincipal CustomUser user,
-                                                                         @RequestParam Long reservationId) {
+                                                                     @RequestParam Long reservationId) {
         try {
-            String qrImage = qrService.generateReservationQr(reservationId);
+            Long memberId = user.getMember().getMemberId();
+            String qrImage = qrService.generateReservationQr(reservationId, memberId);
 
             return ResponseEntity
-                    .status(StatusCode.OK.getStatus())
-                    .body(ApiResponse.of(qrImage, "예약 QR 생성 성공"));
+                    .status(HttpStatus.OK)
+                    .body(ApiResponse.of(qrImage));
 
-        } catch (org.apache.ibatis.exceptions.TooManyResultsException e) {
-            log.warn("예약 정보가 2건 이상 조회됨: reservationId={}", reservationId);
+        } catch (SecurityException e) {
+            log.warn("권한 없음: {}", e.getMessage());
             return ResponseEntity
-                    .status(StatusCode.INTERNAL_ERROR.getStatus())
-                    .body(ApiResponse.error(StatusCode.INTERNAL_ERROR, "예약 정보를 정확히 조회할 수 없습니다. 관리자에게 문의해주세요."));
+                    .status(HttpStatus.FORBIDDEN)
+                    .body(ApiResponse.error(StatusCode.FORBIDDEN, e.getMessage()));
+
+        } catch (NoSuchElementException e) {
+            log.warn("예약 정보 없음: {}", e.getMessage());
+            return ResponseEntity
+                    .status(HttpStatus.NOT_FOUND)
+                    .body(ApiResponse.error(StatusCode.NOT_FOUND, e.getMessage()));
+
+        } catch (IllegalArgumentException e) {
+            log.warn("잘못된 요청: {}", e.getMessage());
+            return ResponseEntity
+                    .status(HttpStatus.BAD_REQUEST)
+                    .body(ApiResponse.error(StatusCode.BAD_REQUEST, e.getMessage()));
 
         } catch (Exception e) {
             log.error("예약 QR 생성 실패", e);
             return ResponseEntity
-                    .status(StatusCode.INTERNAL_ERROR.getStatus())
+                    .status(HttpStatus.INTERNAL_SERVER_ERROR)
                     .body(ApiResponse.error(StatusCode.INTERNAL_ERROR, "예약 QR 생성 중 오류가 발생했습니다. 다시 시도해주세요."));
         }
     }

--- a/src/main/java/org/moa/global/service/qr/QrService.java
+++ b/src/main/java/org/moa/global/service/qr/QrService.java
@@ -5,11 +5,11 @@ import org.moa.member.dto.qr.IdCardResponseDto;
 public interface QrService {
 
     // 주민등록증 QR 생성 및 암호화
-    String generateIdCardQr(Long memberId);
+    String generateIdCardQr(Long memberId) throws Exception;
 
     // 주민등록증 QR 복호화 및 정보 조회
     IdCardResponseDto decryptIdCardQr(String encryptedText);
 
     // 예약 내역 QR 생성 및 암호화
-    String generateReservationQr(Long reservationId);
+    String generateReservationQr(Long reservationId, Long memberId) throws Exception;
 }

--- a/src/main/java/org/moa/global/service/qr/QrServiceImpl.java
+++ b/src/main/java/org/moa/global/service/qr/QrServiceImpl.java
@@ -94,7 +94,7 @@ public class QrServiceImpl implements QrService{
     public String generateReservationQr(Long reservationId) {
         try {
             // 1. DB 조회
-            QrRestaurantReservationDto reservation = reservationMapper.findQrInfo(reservationId);
+            QrRestaurantReservationDto reservation = reservationMapper.findQrInfoByReservationId(reservationId);
             if (reservation == null) {
                 throw new NoSuchElementException("해당 예약 정보를 찾을 수 없습니다.");
             }

--- a/src/main/java/org/moa/reservation/dto/QrAccommodationReservationDto.java
+++ b/src/main/java/org/moa/reservation/dto/QrAccommodationReservationDto.java
@@ -10,7 +10,7 @@ import lombok.Setter;
 @AllArgsConstructor
 @NoArgsConstructor
 public class QrAccommodationReservationDto {
-    private String type = "accommodation"; // 숙박 예약
+    private String type; // 숙박 예약
     private Long reservationId;
     private Long accomId;
     private String hotelName;

--- a/src/main/java/org/moa/reservation/dto/QrAccommodationReservationDto.java
+++ b/src/main/java/org/moa/reservation/dto/QrAccommodationReservationDto.java
@@ -1,0 +1,22 @@
+package org.moa.reservation.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class QrAccommodationReservationDto {
+    private String type = "accommodation"; // 숙박 예약
+    private Long reservationId;
+    private Long accomId;
+    private String hotelName;
+    private String roomType;
+    private String checkinDay;
+    private String checkoutDay;
+    private Integer guests;
+    private String status;
+}

--- a/src/main/java/org/moa/reservation/dto/QrRestaurantReservationDto.java
+++ b/src/main/java/org/moa/reservation/dto/QrRestaurantReservationDto.java
@@ -10,7 +10,7 @@ import lombok.Setter;
 @AllArgsConstructor
 @NoArgsConstructor
 public class QrRestaurantReservationDto {
-    private String type = "restaurant"; // 식당 예약
+    private String type; // 식당 예약
     private Long reservationId;
     private Long restId;
     private String date;

--- a/src/main/java/org/moa/reservation/dto/QrRestaurantReservationDto.java
+++ b/src/main/java/org/moa/reservation/dto/QrRestaurantReservationDto.java
@@ -10,6 +10,7 @@ import lombok.Setter;
 @AllArgsConstructor
 @NoArgsConstructor
 public class QrRestaurantReservationDto {
+    private String type = "restaurant"; // 식당 예약
     private Long reservationId;
     private Long restId;
     private String date;

--- a/src/main/java/org/moa/reservation/dto/QrTransportReservationDto.java
+++ b/src/main/java/org/moa/reservation/dto/QrTransportReservationDto.java
@@ -10,7 +10,7 @@ import lombok.Setter;
 @AllArgsConstructor
 @NoArgsConstructor
 public class QrTransportReservationDto {
-    private String type = "transport"; // 교통 예약
+    private String type; // 교통 예약
     private Long reservationId;
     private Long transportId;
     private String departure;

--- a/src/main/java/org/moa/reservation/dto/QrTransportReservationDto.java
+++ b/src/main/java/org/moa/reservation/dto/QrTransportReservationDto.java
@@ -1,0 +1,22 @@
+package org.moa.reservation.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class QrTransportReservationDto {
+    private String type = "transport"; // 교통 예약
+    private Long reservationId;
+    private Long transportId;
+    private String departure;
+    private String arrival;
+    private Integer seatRoomNo;
+    private String seatNumber;
+    private String seatType;
+    private String status;
+}

--- a/src/main/java/org/moa/reservation/mapper/ReservationMapper.java
+++ b/src/main/java/org/moa/reservation/mapper/ReservationMapper.java
@@ -14,5 +14,5 @@ public interface ReservationMapper {
 	int cancelReservationByReservationId(@Param("reservationId") Long reservationId);
 
 	// 식당 예약 내역 QR
-	QrRestaurantReservationDto findQrInfo(@Param("reservationId") Long reservationId);
+	QrRestaurantReservationDto findQrInfoByReservationId(@Param("reservationId") Long reservationId);
 }

--- a/src/main/java/org/moa/reservation/mapper/ReservationMapper.java
+++ b/src/main/java/org/moa/reservation/mapper/ReservationMapper.java
@@ -2,7 +2,9 @@ package org.moa.reservation.mapper;
 
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
+import org.moa.reservation.dto.QrAccommodationReservationDto;
 import org.moa.reservation.dto.QrRestaurantReservationDto;
+import org.moa.reservation.dto.QrTransportReservationDto;
 import org.moa.reservation.entity.Reservation;
 
 @Mapper
@@ -13,6 +15,19 @@ public interface ReservationMapper {
 
 	int cancelReservationByReservationId(@Param("reservationId") Long reservationId);
 
+	// 식당 / 숙박 / 교통
+	String findTypeByReservationId(@Param("reservationId") Long reservationId);
+
 	// 식당 예약 내역 QR
-	QrRestaurantReservationDto findQrInfoByReservationId(@Param("reservationId") Long reservationId);
+	QrRestaurantReservationDto findRestQrInfoByReservationId(@Param("reservationId") Long reservationId);
+
+	// 숙박 예약 내역 QR
+	QrAccommodationReservationDto findAccomQrInfoByReservationId(@Param("reservationId") Long reservationId);
+
+	// 교통 예약 내역 QR
+	QrTransportReservationDto findTransQrInfoByReservationId(@Param("reservationId") Long reservationId);
+
+	// QR 권한 검증
+	boolean isTripMemberByReservationIdAndMemberId(@Param("reservationId") Long reservationId,
+												   @Param("memberId") Long memberId);
 }

--- a/src/main/resources/org/moa/reservation/mapper/ReservationMapper.xml
+++ b/src/main/resources/org/moa/reservation/mapper/ReservationMapper.xml
@@ -22,9 +22,17 @@
         WHERE r.reservation_id = #{reservationId}
     </select>
 
+    <!-- 식당 / 숙박 / 교통 -->
+    <select id="findTypeByReservationId" resultType="string">
+        SELECT res_kind
+        FROM RESERVATION
+        WHERE reservation_id = #{reservationId}
+    </select>
+
     <!-- 식당 예약 내역 QR -->
-    <select id="findQrInfoByReservationId" resultType="org.moa.reservation.dto.QrRestaurantReservationDto">
+    <select id="findRestQrInfoByReservationId" resultType="org.moa.reservation.dto.QrRestaurantReservationDto">
         SELECT
+            'RESTAURANT' AS type,
             rr.reservation_id AS reservationId,
             rr.rest_id AS restId,
             td.day AS date,
@@ -37,6 +45,49 @@
         WHERE rr.reservation_id = #{reservationId}
     </select>
 
+    <!-- 숙박 예약 내역 QR -->
+    <select id="findAccomQrInfoByReservationId" resultType="org.moa.reservation.dto.QrAccommodationReservationDto">
+        SELECT
+            'ACCOMMODATION' AS type,
+            rr.reservation_id AS reservationId,
+            ra.accom_id AS accomId,
+            ra.hotel_name AS hotelName,
+            ra.room_type AS roomType,
+            DATE_FORMAT(ra.checkin_day, '%Y-%m-%d %H:%i:%s') AS checkinDay,
+            DATE_FORMAT(ra.checkout_day, '%Y-%m-%d %H:%i:%s') AS checkoutDay,
+            ra.guests,
+            ra.status
+        FROM ACCOM_RES ra
+                 JOIN RESERVATION rr ON ra.reservation_id = rr.reservation_id
+        WHERE ra.reservation_id = #{reservationId}
+    </select>
 
+    <!-- 교통 예약 내역 QR -->
+    <select id="findTransQrInfoByReservationId" resultType="org.moa.reservation.dto.QrTransportReservationDto">
+        SELECT
+            'TRANSPORT' AS type,
+            tr.reservation_id AS reservationId,
+            tr.transport_id AS transportId,
+            tr.departure AS departure,
+            tr.arrival AS arrival,
+            tr.seat_room_no AS seatRoomNo,
+            tr.seat_number AS seatNumber,
+            tr.seat_type AS seatType,
+            tr.status AS status
+        FROM TRAN_RES tr
+        WHERE tr.reservation_id = #{reservationId}
+    </select>
+
+    <!-- QR 권한 검증 -->
+    <select id="isTripMemberByReservationIdAndMemberId" resultType="boolean" parameterType="map">
+        SELECT EXISTS (
+            SELECT 1
+            FROM reservation r
+                     JOIN trip_day td ON r.trip_day_id = td.trip_day_id
+                     JOIN trip_member tm ON td.trip_id = tm.trip_id
+            WHERE r.reservation_id = #{reservationId}
+              AND tm.member_id = #{memberId}
+        )
+    </select>
 
 </mapper>

--- a/src/main/resources/org/moa/reservation/mapper/ReservationMapper.xml
+++ b/src/main/resources/org/moa/reservation/mapper/ReservationMapper.xml
@@ -23,16 +23,20 @@
     </select>
 
     <!-- 식당 예약 내역 QR -->
-    <select id="findQrInfo" resultType="org.moa.reservation.dto.QrRestaurantReservationDto">
+    <select id="findQrInfoByReservationId" resultType="org.moa.reservation.dto.QrRestaurantReservationDto">
         SELECT
-            reservation_id AS reservationId,
-            rest_id AS restId,
-            date,
-            res_num AS resNum,
-            status
-        FROM REST_RES
-        WHERE reservation_id = #{reservationId}
+            rr.reservation_id AS reservationId,
+            rr.rest_id AS restId,
+            td.day AS date,
+            rts.res_time AS time,
+            rr.res_num AS resNum,
+            rr.status
+        FROM REST_RES rr
+            JOIN TRIP_DAY td ON rr.trip_day_id = td.trip_day_id
+            JOIN REST_TIME_SLOT rts ON rr.rest_time_id = rts.rest_time_id
+        WHERE rr.reservation_id = #{reservationId}
     </select>
+
 
 
 </mapper>


### PR DESCRIPTION
## PR 종류
사용하지 않는 PR 종류는 삭제해주세요  
- [x] 문서 수정

## 변경 사항

- 사용자 예약 내역을 기반으로 QR 코드를 생성하는 API를 수정했습니다.
- 예약 타입에 따라 (식당/숙박/교통) 각각의 DTO 데이터를 QR에 담도록 설계했습니다.

## 관련 이슈

- (#2 )

## 체크리스트

- [ ] 테스트 코드를 작성하였나요?
- [ ] 모든 테스트가 통과하나요?
- [x] 관련 문서를 업데이트했나요?
- [x] 코드 컨벤션을 지켰나요?

## 상세 내용

- /api/member/qr/reservation?reservationId={id} 형태로 호출

## 기타

- 추가로 알려야 할 사항이 있다면 적어주세요.
