### PR TITLE
fix: 식당 예약 기능 DB 구조 변경 및 코드 수정

### DIFF
--- a/src/main/java/org/moa/reservation/restaurant/dto/AvailableTimeResponseDto.java
+++ b/src/main/java/org/moa/reservation/restaurant/dto/AvailableTimeResponseDto.java
@@ -11,7 +11,7 @@ import lombok.Setter;
 @NoArgsConstructor
 public class AvailableTimeResponseDto {
     private String time;
-    private Long restTimeId;
+    private Long dailySlotId;
     private int maxNum;
     private int reservedNum;
     private int availableNum;

--- a/src/main/java/org/moa/reservation/restaurant/dto/RestaurantReservationInsertDto.java
+++ b/src/main/java/org/moa/reservation/restaurant/dto/RestaurantReservationInsertDto.java
@@ -14,7 +14,6 @@ public class RestaurantReservationInsertDto {
     private Long tripId;
     private Long tripDayId;
     private Long restId;
-    private Long restTimeId;
-    private String resTime;
+    private Long dailySlotId;
     private Integer resNum;
 }

--- a/src/main/java/org/moa/reservation/restaurant/mapper/RestaurantMapper.java
+++ b/src/main/java/org/moa/reservation/restaurant/mapper/RestaurantMapper.java
@@ -30,16 +30,13 @@ public interface RestaurantMapper {
     RestaurantInfoResponseDto findRestaurantInfo(Long restId);
 
     // 예약 가능한 시간대 조회
-    List<String> findTimeSlot(@Param("restId") Long restId);
+    List<AvailableTimeResponseDto> findAvailableSlotsByDate(@Param("restId") Long restId, @Param("date") LocalDate date);
 
-    // 특정 시간에 예약된 인원 수
-    int findReservedCount(@Param("restTimeId") Long restTimeId);
+    // 예약 인원
+    int decreaseCapacity(@Param("dailySlotId") Long dailySlotId, @Param("amount") int amount);
 
-    // 특정 시간대의 최대 예약 가능 인원
-    int findMaxCapacity(@Param("restTimeId") Long restTimeId);
-
-    // restTimeId 조회
-    Long findRestTimeId(@Param("restId") Long restId, @Param("time") String time);
+    // dailySlotId 조회
+    Long findDailySlotId(@Param("restId") Long restId, @Param("date") LocalDate date, @Param("time") String time);
 
     // tripDayId 조회
     Long findTripDayId(@Param("tripId") Long tripId, @Param("date") LocalDate date);

--- a/src/main/resources/org/moa/reservation/mapper/ReservationMapper.xml
+++ b/src/main/resources/org/moa/reservation/mapper/ReservationMapper.xml
@@ -39,12 +39,12 @@
             ri.rest_name AS restName,
             ri.address,
             td.day AS date,
-            CAST(rts.res_time AS TIME) AS time,
+            rds.time AS time,
             rr.res_num AS resNum,
             rr.status
         FROM rest_res rr
             JOIN trip_day td ON rr.trip_day_id = td.trip_day_id
-            JOIN rest_time_slot rts ON rr.rest_time_id = rts.rest_time_id
+            JOIN rest_daily_slot rds ON rr.daily_slot_id = rds.daily_slot_id
             JOIN restaurant_info ri ON rr.rest_id = ri.rest_id
         WHERE rr.rest_res_id = #{restResId}
     </select>
@@ -58,13 +58,13 @@
             ri.rest_name AS restName,
             ri.address,
             td.day AS date,
-            CAST(rts.res_time AS TIME) AS time,
+            rds.time AS time,
             rr.res_num AS resNum,
             rr.status
         FROM rest_res rr
                  JOIN restaurant_info ri ON rr.rest_id = ri.rest_id
                  JOIN trip_day td ON rr.trip_day_id = td.trip_day_id
-                 JOIN rest_time_slot rts ON rr.rest_time_id = rts.rest_time_id
+                 JOIN rest_daily_slot rds ON rr.daily_slot_id = rds.daily_slot_id
         WHERE rr.reservation_id = #{reservationId}
     </select>
 

--- a/src/main/resources/org/moa/reservation/restaurant/mapper/RestaurantMapper.xml
+++ b/src/main/resources/org/moa/reservation/restaurant/mapper/RestaurantMapper.xml
@@ -49,33 +49,37 @@
         WHERE rest_id = #{restId}
     </select>
 
-    <!-- 예약 가능한 시간대 조회 -->
-    <select id="findTimeSlot" resultType="string">
-        SELECT res_time
-        FROM rest_time_slot
+    <!-- 예약 가능한 날짜 시간 조회 -->
+    <select id="findAvailableSlotsByDate" resultType="org.moa.reservation.restaurant.dto.AvailableTimeResponseDto">
+        SELECT
+            daily_slot_id   AS dailySlotId,
+            DATE_FORMAT(rds.time, '%H:%i') AS time,
+            max_capacity    AS maxNum,
+            (max_capacity - current_capacity) AS reservedNum,
+            current_capacity AS availableNum
+        FROM
+            rest_daily_slot rds
+        WHERE
+            rest_id = #{restId}
+          AND day = #{date}
+          AND current_capacity > 0
+    </select>
+
+    <!-- 예약 인원 -->
+    <update id="decreaseCapacity">
+        UPDATE rest_daily_slot
+        SET current_capacity = current_capacity - #{amount}
+        WHERE daily_slot_id = #{dailySlotId}
+          AND current_capacity >= #{amount}
+    </update>
+
+    <!-- dailySlotId 조회 -->
+    <select id="findDailySlotId" resultType="long">
+        SELECT daily_slot_id
+        FROM rest_daily_slot
         WHERE rest_id = #{restId}
-    </select>
-
-    <!-- 특정 시간에 예약된 인원 수 -->
-    <select id="findReservedCount" resultType="int">
-        SELECT COALESCE(SUM(res_num), 0)
-        FROM rest_res
-        WHERE rest_time_id = #{restTimeId}
-    </select>
-
-    <!-- 특정 시간대의 최대 예약 가능 인원 -->
-    <select id="findMaxCapacity" resultType="int">
-        SELECT max_capacity
-        FROM rest_time_slot
-        WHERE rest_time_id = #{restTimeId}
-    </select>
-
-    <!-- restTimeId 조회 -->
-    <select id="findRestTimeId" resultType="long">
-        SELECT rest_time_id
-        FROM rest_time_slot
-        WHERE rest_id = #{restId}
-          AND res_time = #{time}
+          AND day = #{date}
+          AND time = #{time}
     </select>
 
     <!-- tripDayId 조회-->
@@ -103,7 +107,7 @@
             reservation_id,
             trip_day_id,
             rest_id,
-            rest_time_id,
+            daily_slot_id,
             res_num,
             status,
             created_at
@@ -112,7 +116,7 @@
                    #{reservationId},
                    #{tripDayId},
                    #{restId},
-                   #{restTimeId},
+                   #{dailySlotId},
                    #{resNum},
                    'reserved',
                    NOW()
@@ -127,17 +131,17 @@
             ri.rest_id AS restId,
             ri.rest_name AS restName,
             td.day AS date,
-        rts.res_time AS time,
-        rr.res_num AS resNum,
-        rr.status
+            rds.time AS time,
+            rr.res_num AS resNum,
+            rr.status
         FROM
             rest_res rr
-            JOIN restaurant_info ri ON rr.rest_id = ri.rest_id
-            JOIN trip_day td ON rr.trip_day_id = td.trip_day_id
-            JOIN rest_time_slot rts ON rr.rest_time_id = rts.rest_time_id
+                JOIN restaurant_info ri ON rr.rest_id = ri.rest_id
+                JOIN trip_day td ON rr.trip_day_id = td.trip_day_id
+                JOIN rest_daily_slot rds ON rr.daily_slot_id = rds.daily_slot_id -- 수정
         WHERE
             td.trip_id = #{tripId}
-        ORDER BY td.day, rts.res_time
+        ORDER BY td.day, rds.time
     </select>
 
     <!-- 식당 예약 상세 조회 -->
@@ -152,14 +156,14 @@
             ri.category        AS category,
             ri.rest_image_url  AS imageUrl,
             td.day             AS date,
-        rts.res_time       AS time,
-        rr.res_num         AS resNum,
-        rr.status          AS status
+            rds.time           AS time,
+            rr.res_num         AS resNum,
+            rr.status          AS status
         FROM
             rest_res rr
-            JOIN restaurant_info ri ON rr.rest_id = ri.rest_id
-            JOIN trip_day td ON rr.trip_day_id = td.trip_day_id
-            JOIN rest_time_slot rts ON rr.rest_time_id = rts.rest_time_id
+                JOIN restaurant_info ri ON rr.rest_id = ri.rest_id
+                JOIN trip_day td ON rr.trip_day_id = td.trip_day_id
+                JOIN rest_daily_slot rds ON rr.daily_slot_id = rds.daily_slot_id
         WHERE
             rr.rest_res_id = #{restResId}
     </select>
@@ -174,8 +178,8 @@
             MIN(rr.created_at) as createdAt,
             'RESTAURANT' as resKind
         FROM rest_res rr
-            JOIN restaurant_info ri ON rr.rest_id = ri.rest_id
-            JOIN trip_day td ON rr.trip_day_id = td.trip_day_id
+                JOIN restaurant_info ri ON rr.rest_id = ri.rest_id
+                JOIN trip_day td ON rr.trip_day_id = td.trip_day_id
         WHERE td.trip_id = #{tripId}
           AND rr.status IN ('reserved', 'checked_in', 'completed')
         GROUP BY rr.reservation_id, ri.rest_name, rr.rest_id, ri.rest_image_url, td.day


### PR DESCRIPTION
## PR 종류
사용하지 않는 PR 종류는 삭제해주세요  
- [x] 기능 개선
- [ ] 새로운 기능
- [x] 리팩토링
- [ ] 문서 수정
- [ ] 기타

## 변경 사항

- 식당 예약 시스템 DB 스키마 변경
- 예약 가능 시간 조회 API 성능 개선
- 예약 슬롯 자동 생성 기능 추가

## 관련 이슈

- (#30 )

## 체크리스트

- [ ] 테스트 코드를 작성하였나요?
- [ ] 모든 테스트가 통과하나요?
- [ ] 관련 문서를 업데이트했나요?
- [ ] 코드 컨벤션을 지켰나요?

## 상세 내용

- 기존 식당 예약 시간 정보(rest_time_slot)에 날짜 개념이 없어, 모든 날짜에 동일한 시간표만 제공되는 한계가 있었습니다. 또한, 예약 가능 시간을 조회하는 API에서 불필요한 DB 조회가 반복되는 문제가 존재하여 성능 저하의 원인이 되었습니다.

- 추가로 알려야 할 사항이 있다면 적어주세요.
